### PR TITLE
chore: remove vue as dependency to avoid package mixing

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
     "pinia": "3.0.4",
     "tailwindcss": "4.3.0",
     "turndown": "7.2.4",
-    "valibot": "1.4.1",
-    "vue": "3.5.34"
+    "valibot": "1.4.1"
   },
   "devDependencies": {
     "@iconify-json/material-symbols": "1.2.74",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,9 +91,6 @@ importers:
       valibot:
         specifier: 1.4.1
         version: 1.4.1(typescript@5.9.3)
-      vue:
-        specifier: 3.5.34
-        version: 3.5.34(typescript@5.9.3)
     devDependencies:
       '@iconify-json/material-symbols':
         specifier: 1.2.74


### PR DESCRIPTION
Removes `vue` as an explicit dependency since it is already provided transitively through other dependencies in the project, avoiding a redundant declaration.