### PR TITLE
chore: do not explicitely import useStorage

### DIFF
--- a/server/utils/categoryConfigUtils.ts
+++ b/server/utils/categoryConfigUtils.ts
@@ -1,5 +1,3 @@
-import { useStorage } from "nitropack/runtime/storage";
-
 function getCategoryConfigKey(userKey: string): string {
   return `category-config.${userKey}.conf`;
 }

--- a/server/utils/pantryUtils.ts
+++ b/server/utils/pantryUtils.ts
@@ -1,5 +1,3 @@
-import { useStorage } from "nitropack/runtime/storage";
-
 function getPantryKey(userKey: string): string {
   return `pantry.${userKey}.conf`;
 }

--- a/server/utils/recipeIndex.ts
+++ b/server/utils/recipeIndex.ts
@@ -2,7 +2,6 @@ import { Recipe } from "@tmlmt/cooklang-parser";
 import { stat } from "node:fs/promises";
 import path from "node:path";
 import type { RecipeIndex } from "~~/shared/types";
-import { useStorage } from "nitropack/runtime/storage";
 
 const recipeIndex = new Map<string, RecipeIndex[number]>();
 

--- a/server/utils/shoppingIndex.ts
+++ b/server/utils/shoppingIndex.ts
@@ -1,4 +1,3 @@
-import { useStorage } from "nitropack/runtime/storage";
 import { ShoppingList, Recipe } from "@tmlmt/cooklang-parser";
 import type {
   RecipeChoices,


### PR DESCRIPTION
Remove unused `useStorage` imports from server utility files

The `useStorage` import from `nitropack/runtime/storage` was not being used in `categoryConfigUtils.ts`, `pantryUtils.ts`, `recipeIndex.ts`, or `shoppingIndex.ts`, so these dead imports have been removed.