### PR TITLE
fix(middleware): allow shared metadata recipe images

### DIFF
--- a/server/middleware/01-protect-static-assets.ts
+++ b/server/middleware/01-protect-static-assets.ts
@@ -68,5 +68,16 @@ export default defineEventHandler(async (event) => {
     }
   }
 
+  // Fallback: the asset may be a metadata-referenced image whose filename
+  // differs from the recipe's filename, so the derived recipeKey missed it.
+  // Authorize if it appears in a public or share-linked recipe's manifest.
+  const match = pathname.match(/\/recipes\/(.+)/);
+  if (match) {
+    const requestWebPath = `/recipes/${decodeURIComponent(match[1]!)}`;
+    if (await isRecipeAssetPubliclyViewable(requestWebPath)) {
+      return;
+    }
+  }
+
   await requireUserSession(event);
 });

--- a/server/utils/recipeImages.ts
+++ b/server/utils/recipeImages.ts
@@ -1,6 +1,7 @@
 import { readdir, stat } from "node:fs/promises";
 import * as nodePath from "node:path";
 import type { RecipeImageManifest } from "~~/shared/types";
+import { Recipe } from "@tmlmt/cooklang-parser";
 
 export const IMAGE_EXTENSIONS = ["jpg", "jpeg", "png", "webp", "gif", "avif"];
 
@@ -262,4 +263,85 @@ export async function buildImageManifest(
     hasImages:
       heroImages.length > 0 || Object.keys(stepImagesByNumber).length > 0,
   };
+}
+
+/**
+ * Authorizes access to a recipe image asset whose filename does not match its
+ * recipe's filename (e.g. images referenced via the `images:` metadata field,
+ * which can be named arbitrarily).
+ *
+ * Scans the .cook recipes in the asset's directory and returns true if the
+ * asset appears in the image manifest of any recipe that is public or has an
+ * active (non-expired) share link. Used as a fallback by the static-asset
+ * protection middleware after the filename-derived recipe key fails to match.
+ */
+export async function isRecipeAssetPubliclyViewable(
+  requestWebPath: string,
+): Promise<boolean> {
+  if (!requestWebPath.startsWith("/recipes/")) return false;
+
+  const relative = requestWebPath.slice("/recipes/".length);
+  const dirRelative = nodePath.dirname(relative);
+  const dirFsPath =
+    dirRelative === "." ? recipesRoot : nodePath.join(recipesRoot, dirRelative);
+
+  let dirEntries;
+  try {
+    dirEntries = await readdir(dirFsPath, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+
+  // Collect the base recipe key (colon-separated, locale stripped) of each
+  // .cook variant in the directory.
+  const baseKeys = new Set<string>();
+  for (const entry of dirEntries) {
+    if (!entry.isFile() || !entry.name.endsWith(".cook")) continue;
+    const fileKey =
+      (dirRelative === "." ? "" : `${dirRelative}/`) +
+      entry.name.slice(0, -".cook".length);
+    baseKeys.add(parseRecipeKey(fileKey.replace(/\//g, ":")).baseKey);
+  }
+
+  const db = getDb();
+  const storage = useStorage("recipes");
+
+  for (const baseKey of baseKeys) {
+    const isPublic = await isRecipePublic(baseKey);
+    let viewable = isPublic;
+    if (!viewable) {
+      const activeShareLink = await db.shareLink.findFirst({
+        where: {
+          recipePath: baseKey,
+          OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+        },
+      });
+      viewable = Boolean(activeShareLink);
+    }
+    if (!viewable) continue;
+
+    const baseFilePath = baseKey.replace(/:/g, "/");
+    const content = await storage.getItem(`${baseFilePath}.cook`);
+    if (!content) continue;
+
+    let metadata: Record<string, unknown>;
+    try {
+      metadata = new Recipe(String(content)).metadata as Record<
+        string,
+        unknown
+      >;
+    } catch {
+      continue;
+    }
+
+    const manifest = await buildImageManifest(baseFilePath, metadata);
+    const assets = [
+      ...(manifest.coverImage ? [manifest.coverImage] : []),
+      ...manifest.heroImages,
+      ...Object.values(manifest.stepImagesByNumber),
+    ];
+    if (assets.includes(requestWebPath)) return true;
+  }
+
+  return false;
 }


### PR DESCRIPTION
Fixes access to recipe images whose filenames differ from their parent recipe's filename.

Previously, the static asset protection middleware derived a recipe key directly from the requested asset's filename. This worked for conventionally named images but failed for images referenced via the `images:` metadata field, which can be named arbitrarily. Those images were incorrectly blocked even when the recipe was public or shared via an active share link.

Adds a fallback authorization path that scans `.cook` files in the asset's directory, checks whether any of them are public or have a valid share link, and if so, builds that recipe's image manifest to verify the requested asset is legitimately referenced before granting access.