### PR TITLE
fix(recipe-move): keep metadata image filenames unchanged

### DIFF
--- a/server/api/recipe/[...path]/index.patch.ts
+++ b/server/api/recipe/[...path]/index.patch.ts
@@ -54,7 +54,8 @@ export default defineEventHandler(async (event) => {
   // Update visibility overrides and share links to new path
   await moveRecipeVisibilityAndLinks(oldRecipeKey, newRecipeKey);
 
-  // Move associated images
+  // Move associated images. Only managed cover/step files are renamed to the
+  // new recipe base name; metadata-referenced files keep their basename.
   const oldRecipeName = nodePath.basename(decodedPath);
   const oldRecipeDirFsPath = nodePath.join(
     recipesRoot,
@@ -70,11 +71,22 @@ export default defineEventHandler(async (event) => {
       oldRecipeName,
     );
 
+    const managedImagePaths = new Set<string>([
+      ...(discovered.cover ? [discovered.cover] : []),
+      ...Object.values(discovered.steps),
+    ]);
+
     for (const oldFsPath of discovered.all) {
       const oldBasename = nodePath.basename(oldFsPath);
-      // Replace old recipe name prefix with new recipe name
-      const newBasename = fileName + oldBasename.slice(oldRecipeName.length);
+      const shouldRenameBasename = managedImagePaths.has(oldFsPath);
+      const newBasename = shouldRenameBasename
+        ? fileName + oldBasename.slice(oldRecipeName.length)
+        : oldBasename;
       const newFsPath = nodePath.join(newRecipeDirFsPath, newBasename);
+
+      if (newFsPath === oldFsPath) {
+        continue;
+      }
 
       // Security: ensure target stays within recipesRoot
       if (


### PR DESCRIPTION
When renaming a recipe, only managed image files (cover and step images) should have their basename updated to reflect the new recipe name. Previously, all associated images were unconditionally renamed using the old recipe name as a prefix, which would corrupt filenames for metadata-referenced images that don't follow that naming convention.

This change introduces a set of managed image paths derived from the discovered cover and step images. During the rename loop, only files in that set get their basename updated; all other files retain their original basename. A short-circuit is also added to skip the move entirely when the resolved source and destination paths are identical.