### PR TITLE
fix: implement missing function to move recipes in the index

### DIFF
--- a/server/utils/recipeIndex.ts
+++ b/server/utils/recipeIndex.ts
@@ -291,3 +291,25 @@ export function deleteFromRecipeIndex(key: string) {
     });
   }
 }
+
+/**
+ * Moves a recipe index entry and its variant tracker from oldKey to newKey,
+ * updating the dir field to reflect the new location.
+ * Called when a recipe file or folder is renamed or moved.
+ */
+export function moveInRecipeIndex(
+  oldKey: string,
+  newKey: string,
+  newDir: string,
+) {
+  const entry = recipeIndex.get(oldKey);
+  const tracker = variantTracker.get(oldKey);
+  if (entry) {
+    recipeIndex.delete(oldKey);
+    recipeIndex.set(newKey, { ...entry, dir: newDir });
+  }
+  if (tracker) {
+    variantTracker.delete(oldKey);
+    variantTracker.set(newKey, tracker);
+  }
+}


### PR DESCRIPTION
Adds a `moveInRecipeIndex` function that handles renaming or moving a recipe file or folder. When called with an old key, new key, and new directory path, it transfers the existing recipe index entry and its associated variant tracker to the new key, updating the `dir` field to reflect the new location.