### PR TITLE
fix(typecheck): extend test tsconfig with Nuxt server type context to avoid out-of-context errors

### DIFF
--- a/tsconfig.scripts.tsbuildinfo
+++ b/tsconfig.scripts.tsbuildinfo
@@ -1,8 +1,1 @@
-{
-  "root": [
-    "./scripts/hash-password.mjs",
-    "./scripts/release.mjs",
-    "./scripts/update-translation-status.mjs"
-  ],
-  "version": "6.0.3"
-}
+{"root":["./scripts/hash-password.mjs","./scripts/release.mjs","./scripts/update-translation-status.mjs"],"version":"6.0.3"}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,19 +1,4 @@
 {
-  "include": ["test/**/*"],
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "Bundler",
-    "allowJs": true,
-    "strict": true,
-    "noEmit": true,
-    "skipLibCheck": true,
-    "paths": {
-      "~~/*": ["./*"],
-      "@/*": ["./*"],
-      "nitropack/runtime": [
-        "./node_modules/.pnpm/nitropack@2.13.2_@electric-sql+pglite@0.4.1_better-sqlite3@12.9.0_mysql2@3.15.3/node_modules/nitropack/runtime"
-      ]
-    }
-  }
+  "extends": "./.nuxt/tsconfig.server.json",
+  "include": ["test/**/*", ".nuxt/types/nitro.d.ts", "shared/**/*.d.ts"]
 }

--- a/tsconfig.test.tsbuildinfo
+++ b/tsconfig.test.tsbuildinfo
@@ -1,1 +1,1 @@
-{"root":["./test/unit/migrations.test.ts","./test/unit/regex.test.ts","./test/unit/shoppingIndex.test.ts","./test/unit/validateRecipeDir.test.ts","./test/unit/validateRecipePath.test.ts"],"errors":true,"version":"6.0.3"}
+{"root":["./test/unit/migrations.test.ts","./test/unit/regex.test.ts","./test/unit/shoppingIndex.test.ts","./test/unit/validateRecipeDir.test.ts","./test/unit/validateRecipePath.test.ts","./.nuxt/types/nitro.d.ts","./shared/auth.d.ts"],"version":"6.0.3"}


### PR DESCRIPTION
Simplify `tsconfig.test.json` by extending `.nuxt/tsconfig.server.json` instead of manually specifying compiler options. This removes the hardcoded `paths` aliases and compiler settings, replacing them with the generated Nuxt server config. The `include` paths are also updated to incorporate Nitro and shared type definitions, resolving previous type errors in the test build.